### PR TITLE
General cleanup to make sure entire site is usable

### DIFF
--- a/apps/nerves_hub_www/assets/css/_audit_log_feed.scss
+++ b/apps/nerves_hub_www/assets/css/_audit_log_feed.scss
@@ -21,6 +21,7 @@
     background-position: center;
     background-repeat: no-repeat;
     background-size: 1.75rem 1.5rem;
+    background-image: url("/images/icons/activity-update.svg");
 
     &.icon-create {
       background-image: url("/images/icons/activity-create.svg");

--- a/apps/nerves_hub_www/assets/css/_buttons.scss
+++ b/apps/nerves_hub_www/assets/css/_buttons.scss
@@ -70,6 +70,10 @@ html {
     margin-top: 2rem;
     display: flex;
     align-items: center;
+
+    .btn + .btn {
+      margin-left: 1.5rem;
+    }
   }
 
   .btn-sm {

--- a/apps/nerves_hub_www/assets/css/_console.scss
+++ b/apps/nerves_hub_www/assets/css/_console.scss
@@ -20,8 +20,7 @@
 .console-input {
   color: inherit;
   font-family: inherit;
-  width: inherit;
-  border:none;
+  border: none;
   background-image:none;
   background-color:transparent;
   -webkit-box-shadow: none;

--- a/apps/nerves_hub_www/assets/css/_footer.scss
+++ b/apps/nerves_hub_www/assets/css/_footer.scss
@@ -6,17 +6,16 @@
   padding: 4rem 0;
   justify-content: center;
 
+  h6 {
+    margin-bottom: .35rem;
+  }
+
   & > div {
     padding: 0 1.25rem;
     max-width: 780px;
   }
 
   a {
-    color: white;
     margin: .35rem 0;
-
-    &:hover {
-      color: var(--primary-25)
-    }
   }
 }

--- a/apps/nerves_hub_www/assets/css/_typography.scss
+++ b/apps/nerves_hub_www/assets/css/_typography.scss
@@ -28,6 +28,10 @@ body {
     color: white;
     line-height: 30px;
     margin: 0;
+
+    & + p {
+      margin-top: 1rem;
+    }
   }
 
   h4,
@@ -67,6 +71,10 @@ body {
 
     &:last-child {
       margin: 0;
+    }
+
+    & + h3 {
+      margin-top: 2rem;
     }
   }
 

--- a/apps/nerves_hub_www/assets/css/app.scss
+++ b/apps/nerves_hub_www/assets/css/app.scss
@@ -46,9 +46,12 @@ body {
   }
 }
 
-html main.content-container {
-  margin-bottom: 8rem;
-  min-height: 100%;
+html {
+  main.content-container {
+    margin: 0 auto;
+    padding-bottom: 8rem;
+    min-height: calc(100vh - 80px);
+  }
 }
 
 .badge {

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/firmware_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/firmware_controller.ex
@@ -41,7 +41,7 @@ defmodule NervesHubWWWWeb.FirmwareController do
       {:error, :invalid_signature} ->
         render_error(
           conn,
-          "Firmware corrupt, signature invalid or missing public key",
+          "Firmware corrupt, signature invalid, or missing public key",
           %Changeset{data: %Firmware{}}
         )
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/edit.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/edit.html.eex
@@ -1,40 +1,36 @@
-<h1>Edit deployment</h1>
+<h1>Edit Deployment</h1>
+
+<h3 class="h3 mb-1">Firmware Details</h3>
+<div class="x4-grid">
+  <div>
+    <div class="help-text mb-1">Product</div>
+    <p><%= @product.name %></p>
+  </div>
+  <div>
+    <div class="help-text mb-1">Version</div>
+    <p>
+      <%=
+          case @firmware.version do
+            nil -> "--"
+            version -> version
+          end
+        %>
+    </p>
+  </div>
+  <div>
+    <div class="help-text mb-1">Platform</div>
+    <p><%= @firmware.platform %></p>
+  </div>
+  <div>
+    <div class="help-text mb-1">Architecture</div>
+    <p><%= @firmware.architecture %></p>
+  </div>
+</div>
+
+<div class="divider"></div>
 
 <%= form_for @changeset, Routes.deployment_path(@conn, :update, @org.name, @product.name, @deployment.name), [as: :deployment], fn f -> %>
-  <h3 class="h3">Firmware Details</h3>
-
-  <table class="table" style="width: auto">
-    <tbody>
-      <tr>
-        <th>Product</th>
-        <td><%= @product.name %></td>
-      </tr>
-      <tr>
-        <th>Version</th>
-        <td>
-          <%=
-            case @firmware.version do
-              nil -> "--"
-              version -> version
-            end
-          %>
-        </td>
-      </tr>
-      <tr>
-        <th>Platform</th>
-        <td><%= @firmware.platform %></td>
-      </tr>
-      <tr>
-        <th>Architecture</th>
-        <td><%= @firmware.architecture %></td>
-      </tr>
-    </tbody>
-  </table>
-
   <%= hidden_input f, :firmware_id, value: @firmware.id %>
-
-  <h3 class="h3">Deployment</h3>
-
   <div class="form-group">
     <label for="name_input">Name</label>
     <%= text_input f, :name, class: "form-control", id: "name_input" %>
@@ -117,5 +113,7 @@
     <div class="has-error"><%= error_tag f, :device_failure_rate_seconds %></div>
   </div>
 
-  <%= submit "Update Deployment", class: "btn btn-primary" %>
+  <div class="button-submit-wrapper">
+    <%= submit "Update Deployment", class: "btn btn-primary" %>
+  </div>
 <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/index.html.eex
@@ -41,7 +41,7 @@
           </span>
         </td>
         <td class="actions">
-          <%= link "", class: "fa fa-trash-alt", to: Routes.deployment_path(@conn, :delete, @org.name, @product.name, deployment.name), method: :delete, data: [confirm: "Are you sure you want to delete this deployment? This can not be undone."] %>
+          <%= link "delete", class: "fa fa-trash-alt color-white", to: Routes.deployment_path(@conn, :delete, @org.name, @product.name, deployment.name), method: :delete, data: [confirm: "Are you sure you want to delete this deployment? This can not be undone."] %>
         </td>
       </tr>
     <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/new.html.eex
@@ -1,19 +1,17 @@
-<div class="modal-content shadow">
-  <%= form_for @changeset, Routes.deployment_path(@conn, :create, @org.name, @product.name), [as: :deployment], fn f -> %>
-    <div class="modal-header panel-title rounded-top">
-      Create Deployment for <strong><%= firmware_summary(@firmware) %></strong>
-    </div>
-    <div class="modal-body">
-      <%= hidden_input f, :firmware_id, value: @firmware.id %>
-      <div class="form-group">
-        <label for="name_input">Name</label>
-        <%= text_input f, :name, class: "form-control", id: "name_input" %>
-        <div class="has-error"><%= error_tag f, :name %></div>
-      </div>
+<h1>Add Deployment</h1>
 
-      <div class="form-group">
-        <label for="verion_input">Version Requirement</label>
-        <%= text_input f, :version,
+<%= form_for @changeset, Routes.deployment_path(@conn, :create, @org.name, @product.name), [as: :deployment], fn f -> %>
+
+  <%= hidden_input f, :firmware_id, value: @firmware.id %>
+  <div class="form-group">
+    <label for="name_input">Name</label>
+    <%= text_input f, :name, class: "form-control", id: "name_input" %>
+    <div class="has-error"><%= error_tag f, :name %></div>
+  </div>
+
+  <div class="form-group">
+    <label for="verion_input">Version Requirement</label>
+    <%= text_input f, :version,
           class: "form-control",
           id: "version_input",
           value:
@@ -21,12 +19,12 @@
             |> Ecto.Changeset.get_change(:conditions, %{})
             |> Map.get("version", "")
         %>
-        <div class="has-error"><%= error_tag f, :version %></div>
-      </div>
+    <div class="has-error"><%= error_tag f, :version %></div>
+  </div>
 
-      <div class="form-group">
-        <label for="verion_input">Tag(s)*</label>
-        <%= text_input f, :tags,
+  <div class="form-group">
+    <label for="verion_input">Tag(s)*</label>
+    <%= text_input f, :tags,
           class: "form-control",
           id: "version_input",
           value:
@@ -34,18 +32,11 @@
             |> Ecto.Changeset.get_change(:conditions, %{})
             |> Map.get("tags", "")
         %>
-        <div class="has-error"><%= error_tag f, :tags %></div>
-      </div>
-    </div>
-    <div class="modal-footer">
-      <div class="col-4">
-        <a class="btn btn-secondary" href="<%= Routes.deployment_path(@conn, :index, @org.name, @product.name) %>">
-          Cancel
-        </a>
-      </div>
-      <div class="col-8 text-right">
-        <%= submit "Create Deployment", class: "btn btn-primary" %>
-      </div>
-    </div>
-  <% end %>
-</div>
+    <div class="has-error"><%= error_tag f, :tags %></div>
+  </div>
+
+  <div class="button-submit-wrapper">
+    <a class="btn btn-secondary" href="<%= Routes.deployment_path(@conn, :index, @org.name, @product.name) %>">Cancel</a>
+    <%= submit "Create Deployment", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/select-firmware.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/select-firmware.html.eex
@@ -1,24 +1,15 @@
-<div class="modal-content shadow">
-  <%= form_for @conn, Routes.deployment_path(@conn, :new, @org.name, @product.name), [method: :get, as: :deployment], fn f -> %>
-    <div class="modal-header panel-title rounded-top">
-      Select Firmware for New Deployment
-    </div>
-    <div class="modal-body">
-      <div class="form-group">
-        <label for="firmware_id">Firmware</label>
-        <%= select f, :firmware_id, firmware_dropdown_options(@firmwares), required: true, id: "firmware_id", class: "form-control" %>
-        <div class="has-error"><%= error_tag f, :firmware_id %></div>
-      </div>
-    </div>
-    <div class="modal-footer">
-      <div class="col-4">
-        <a class="btn btn-secondary" href="<%= Routes.deployment_path(@conn, :index, @org.name, @product.name) %>">
-          Cancel
-        </a>
-      </div>
-      <div class="col-8 text-right">
-        <%= submit "Select", class: "btn btn-primary" %>
-      </div>
-    </div>
-  <% end %>
-</div>
+<h1>Select Firmware</h1>
+<%= form_for @conn, Routes.deployment_path(@conn, :new, @org.name, @product.name), [method: :get, as: :deployment], fn f -> %>
+  <div class="form-group">
+    <label for="firmware_id">Firmware</label>
+    <%= select f, :firmware_id, firmware_dropdown_options(@firmwares), required: true, id: "firmware_id", class: "form-control" %>
+    <div class="has-error"><%= error_tag f, :firmware_id %></div>
+  </div>
+
+  <div class="button-submit-wrapper">
+    <a class="btn btn-secondary" href="<%= Routes.deployment_path(@conn, :index, @org.name, @product.name) %>">
+      Cancel
+    </a>
+    <%= submit "Select", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/show.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/show.html.leex
@@ -1,81 +1,76 @@
-<div class="container-fluid">
-  <div class="row">
-    <div class="col-lg-7">
-    <h1>
-  Deployment:
-  <%= @deployment.name %>
-</h1>
+<h1>Deployment: <%= @deployment.name %></h1>
 
-<table class="table" style="width: auto">
-  <tbody>
-    <tr>
-      <th>Product</th>
-      <td><%= @product.name %></td>
-    </tr>
-    <tr>
-      <th>Active</th>
-      <td><%= active(@deployment) %>
-    </tr>
-    <tr>
-      <th>Healthy?</th>
-      <td><%= health_status_icon(@deployment) %>
-    </tr>
-    <tr>
-      <th>Version Requirement</th>
-      <td><%= version(@deployment) %></td>
-    </tr>
-    <tr>
-      <th>Tags</th>
-      <td>
-        <%= for tag <- tags(@deployment) do %>
-          <span class="badge">
-            <%= tag %>
-          </span>
-        <% end %>
-      </td>
-    </tr>
-    <tr>
-      <th>Firmware Info</th>
-      <td><%= firmware_summary(@deployment) %></td>
-    </tr>
-    <tr>
-      <th>Failure Rate <%= help_icon(help_message_for(:failure_rate)) %></th>
-      <td><%= @deployment.failure_rate_amount %> device failures per <%= @deployment.failure_rate_seconds %> seconds</td>
-    </tr>
-    <tr>
-      <th>Failure Threshold <%= help_icon(help_message_for(:failure_threshold)) %></th>
-      <td><%= @deployment.failure_threshold %></td>
-    </tr>
-    <tr>
-      <th>Device Failure Rate <%= help_icon(help_message_for(:device_failure_rate)) %></th>
-      <td><%= @deployment.device_failure_rate_amount %> failures per <%= @deployment.device_failure_rate_seconds %> seconds</td>
-    </tr>
-    <tr>
-      <th>Device Failure Threshold <%= help_icon(help_message_for(:device_failure_threshold)) %></th>
-      <td><%= @deployment.device_failure_threshold %></td>
-    </tr>
-  </tbody>
-</table>
+<div class="divider"></div>
 
 <div class="row">
-<a class="btn btn-primary mr-3" href="<%= Routes.deployment_path(@socket, :edit, @org.name, @product.name, @deployment.name) %>">
-  Edit Deployment
-</a>
+  <div class="col-lg-7">
+    <table class="table" style="width: auto">
+      <tbody>
+        <tr>
+          <th>Product</th>
+          <td><%= @product.name %></td>
+        </tr>
+        <tr>
+          <th>Active</th>
+          <td><%= active(@deployment) %>
+        </tr>
+        <tr>
+          <th>Healthy?</th>
+          <td><%= health_status_icon(@deployment) %>
+        </tr>
+        <tr>
+          <th>Version Requirement</th>
+          <td><%= version(@deployment) %></td>
+        </tr>
+        <tr>
+          <th>Tags</th>
+          <td>
+            <%= for tag <- tags(@deployment) do %>
+              <span class="badge">
+                <%= tag %>
+              </span>
+            <% end %>
+          </td>
+        </tr>
+        <tr>
+          <th>Firmware Info</th>
+          <td><%= firmware_summary(@deployment) %></td>
+        </tr>
+        <tr>
+          <th>Failure Rate <%= help_icon(help_message_for(:failure_rate)) %></th>
+          <td><%= @deployment.failure_rate_amount %> device failures per <%= @deployment.failure_rate_seconds %> seconds</td>
+        </tr>
+        <tr>
+          <th>Failure Threshold <%= help_icon(help_message_for(:failure_threshold)) %></th>
+          <td><%= @deployment.failure_threshold %></td>
+        </tr>
+        <tr>
+          <th>Device Failure Rate <%= help_icon(help_message_for(:device_failure_rate)) %></th>
+          <td><%= @deployment.device_failure_rate_amount %> failures per <%= @deployment.device_failure_rate_seconds %> seconds</td>
+        </tr>
+        <tr>
+          <th>Device Failure Threshold <%= help_icon(help_message_for(:device_failure_threshold)) %></th>
+          <td><%= @deployment.device_failure_threshold %></td>
+        </tr>
+      </tbody>
+    </table>
 
-<a class="btn btn-primary mr-3" phx-click="toggle_active" phx-value-isactive=<%= !@deployment.is_active %>>Make <%= opposite_status(@deployment) %></a>
-
-<%= form_for %Plug.Conn{}, "#", [phx_submit: "toggle_health_state"], fn _f -> %>
-  <%= submit "Mark #{if @deployment.healthy, do: "Unhealthy", else: "Healthy"}", class: "btn btn-primary mr-3" %>
-<% end %>
-
-<%= form_for %Plug.Conn{}, "#", [phx_submit: "delete"], fn _f -> %>
-  <%= submit "Delete Deployment", class: "btn btn-danger", onclick: "return confirm('Are you sure you want to delete this deployment? This can not be undone.')" %>
-<% end %>
-</div>
+    <div class="button-submit-wrapper">
+      <a class="btn btn-primary" href="<%= Routes.deployment_path(@socket, :edit, @org.name, @product.name, @deployment.name) %>">
+        Edit Deployment
+      </a>
+      <a class="btn btn-primary" phx-click="toggle_active" phx-value-isactive=<%= !@deployment.is_active %>>Make <%= opposite_status(@deployment) %></a>
+      <%= form_for %Plug.Conn{}, "#", [phx_submit: "toggle_health_state"], fn _f -> %>
+        <%= submit "Mark #{if @deployment.healthy, do: "Unhealthy", else: "Healthy"}", class: "btn btn-primary" %>
+      <% end %>
+      <%= form_for %Plug.Conn{}, "#", [phx_submit: "delete"], fn _f -> %>
+        <%= submit "Delete Deployment", class: "btn btn-danger", onclick: "return confirm('Are you sure you want to delete this deployment? This can not be undone.')" %>
+      <% end %>
     </div>
-    <div class="col-lg-5">
-      <%= render(NervesHubWWWWeb.AuditLogView, "_audit_log_feed.html", assigns) %>
-    </div>
+  </div>
+
+  <div class="col-lg-5">
+    <%= render(NervesHubWWWWeb.AuditLogView, "_audit_log_feed.html", assigns) %>
   </div>
 </div>
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/console.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/console.html.eex
@@ -1,7 +1,7 @@
 <%= if @console_available == true do %>
-  <input id="device_id" hidden type="text" value="<%= @device.id %>">
+  <input id="device_id" hidden type="text" value="<%= @device.id %>" />
   <div id="terminal" class="console"></div>
   <button class="btn btn-danger" id="restart_button">Restart</button>
 <% else %>
-  <h1>Console disabled or unavailable
+  <h1>Console disabled or unavailable</h1>
 <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/index.html.eex
@@ -37,8 +37,8 @@
         <td data-toggle="collapse" data-target="#firmware<%= firmware.id %>"><%= firmware.platform %></td>
         <td data-toggle="collapse" data-target="#firmware<%= firmware.id %>"><%= format_signed(firmware, @org) %></td>
         <td class="actions">
-          <%= link("", class: "fa fa-file-download", to: Routes.firmware_path(@conn, :download, @org.name, @product.name, firmware.uuid)) %>
-          <%= link "", class: "fa fa-trash-alt", to: Routes.firmware_path(@conn, :delete, @org.name, @product.name, firmware.uuid), method: :delete, data: [confirm: "Are you sure you want to delete this firmware? This can not be undone."] %>
+          <%= link("", class: "fa fa-file-download color-white", to: Routes.firmware_path(@conn, :download, @org.name, @product.name, firmware.uuid)) %>
+          <%= link "", class: "fa fa-trash-alt color-white", to: Routes.firmware_path(@conn, :delete, @org.name, @product.name, firmware.uuid), method: :delete, data: [confirm: "Are you sure you want to delete this firmware? This can not be undone."] %>
         </td>
       </tr>
       <tr class="item collapsible">

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/upload.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/upload.html.eex
@@ -1,24 +1,13 @@
-<div class="modal-content shadow">
-  <%= form_for @changeset, Routes.firmware_path(@conn, :do_upload, @org.name, @product.name), [multipart: true], fn f -> %>
-    <div class="modal-header panel-title rounded-top">
-      Upload firmware for <strong><%= @product.name %></strong>
-    </div>
-    <div class="modal-body">
-      <div class="form-group">
-        <label for="file_input">Select File</label>
-        <%= file_input f, :file, required: true, id: "file_input" %>
-        <div class="has-error"><%= error_tag f, :file %></div>
-      </div>
-    </div>
-    <div class="modal-footer">
-      <div class="col-4">
-        <a class="btn btn-secondary" href="<%= Routes.product_path(@conn, :index, @org.name) %>">
-          Cancel
-        </a>
-      </div>
-      <div class="col-8 text-right">
-        <%= submit "Upload Firmware", class: "btn btn-primary" %>
-      </div>
-    </div>
-  <% end %>
-</div>
+<h1>Add Firmware</h1>
+
+<%= form_for @changeset, Routes.firmware_path(@conn, :do_upload, @org.name, @product.name), [multipart: true], fn f -> %>
+  <div class="form-group">
+    <label for="file_input">Select File</label>
+    <%= file_input f, :file, required: true, id: "file_input" %>
+    <div class="has-error"><%= error_tag f, :file %></div>
+  </div>
+  <div class="button-submit-wrapper">
+    <a class="btn btn-secondary" href="<%= Routes.product_path(@conn, :index, @org.name) %>">Cancel</a>
+    <%= submit "Upload Firmware", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_footer.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_footer.html.eex
@@ -1,9 +1,7 @@
 <footer class="footer">
   <div class="flex-row justify-content-between w-100">
     <div class="flex-column">
-      <h6>
-        NervesHub
-      </h6>
+      <h6>NervesHub</h6>
       <a href="https://github.com/nerves-hub">Source code</a>
       <a href="<%= Routes.nerves_key_path(@conn, :index) %>">NervesKey</a>
       <a href="<%= Routes.sponsor_path(@conn, :index) %>">Sponsors</a>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/app.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/app.html.eex
@@ -34,25 +34,23 @@
 
   <body>
     <%= render("_navigation.html", conn: @conn) %>
-    <div class="flex-column align-items-center h-100">
-      <main role="main" class="flex-column content-container">
-        <%= if get_flash(@conn, :info) do %>
-          <div class="alert alert-info alert-dismissible">
-            <button type="button" class="close" data-dismiss="alert">&times;</button>
-            <%= get_flash(@conn, :info) %>
-          </div>
-        <% end %>
-        <%= if get_flash(@conn, :error) do %>
-          <div class="alert alert-danger alert-dismissible">
-            <button type="button" class="close" data-dismiss="alert">&times;</button>
-            <%= get_flash(@conn, :error) %>
-          </div>
-        <% end %>
-        <%= render("_tabnav.html", conn: @conn) %>
-        <%= render @view_module, @view_template, assigns %>
-      </main>
-      <%= render("_footer.html", conn: @conn) %>
-    </div>
+    <main role="main" class="flex-column content-container">
+      <%= if get_flash(@conn, :info) do %>
+        <div class="alert alert-info alert-dismissible">
+          <button type="button" class="close" data-dismiss="alert">&times;</button>
+          <%= get_flash(@conn, :info) %>
+        </div>
+      <% end %>
+      <%= if get_flash(@conn, :error) do %>
+        <div class="alert alert-danger alert-dismissible">
+          <button type="button" class="close" data-dismiss="alert">&times;</button>
+          <%= get_flash(@conn, :error) %>
+        </div>
+      <% end %>
+      <%= render("_tabnav.html", conn: @conn) %>
+      <%= render @view_module, @view_template, assigns %>
+    </main>
+    <%= render("_footer.html", conn: @conn) %>
     <script>
       window.userToken = "<%= assigns[:user_token] %>"
       window.orgId = "<%= assigns[:org] && Map.get(assigns[:org], :id) %>"

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/invite.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/invite.html.eex
@@ -26,7 +26,7 @@
   </div>
 
   <div class="button-submit-wrapper">
-    <a class="btn btn-outline-light mr-3" href="<%= Routes.org_user_path(@conn, :index, @org.name) %>">Cancel</a>
+    <a class="btn btn-outline-light" href="<%= Routes.org_user_path(@conn, :index, @org.name) %>">Cancel</a>
     <%= submit "Send Invitation", class: "btn btn-primary" %>
   </div>
 <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_key/form.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_key/form.html.eex
@@ -18,9 +18,9 @@
   </div>
 
   <div class="button-submit-wrapper">
-    <%= link "Back", to: Routes.org_key_path(@conn, :index, @org.name), class: "btn btn-outline-light mr-3" %>
+    <%= link "Back", to: Routes.org_key_path(@conn, :index, @org.name), class: "btn btn-outline-light" %>
     <%= if assigns[:org_key] do %>
-      <%= link "Remove", to: Routes.org_key_path(@conn, :delete, @org.name, @org_key), method: :delete, data: [confirm: "Are you sure you want to delete this firmware key? This can not be undone."], class: "btn btn-secondary mr-3" %>
+      <%= link "Remove", to: Routes.org_key_path(@conn, :delete, @org.name, @org_key), method: :delete, data: [confirm: "Are you sure you want to delete this firmware key? This can not be undone."], class: "btn btn-secondary" %>
       <%= submit "Save Changes", class: "btn btn-primary" %>
     <% else %>
       <%= submit "Create Key", class: "btn btn-primary" %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/policy/coc.html.md
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/policy/coc.html.md
@@ -1,4 +1,6 @@
-## Code of Conduct
+<div class="pb-6"></div>
+
+# Code of Conduct
 
 NervesHub exists to facilitate sharing firmware, by making it easy for Nerves  developers to publish firmware and manage embedded devices.
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/policy/privacy.html.md
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/policy/privacy.html.md
@@ -1,4 +1,6 @@
-## Privacy Policy
+<div class="pb-6"></div>
+
+# Privacy Policy
 
 We store information about access to and users on the [nerves-hub.org](https://nerves-hub.org/) website, the nerves-hub.org API and repository. This data is stored in the US on Amazon AWS servers.
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/policy/tos.html.md
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/policy/tos.html.md
@@ -1,4 +1,6 @@
-## Terms of Service
+<div class="pb-6"></div>
+
+# Terms of Service
 
 By accessing or using the nerves-hub.org websites, HTTP API, repository or associated services (collectively, the "Services") of nerves-hub.org ("NervesHub") you are agreeing to be bound by this Terms of Service ("Terms"). Any information, text, graphics or other material on Services (collectively, the "Content") is also covered by the Terms.
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/form.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/product/form.html.eex
@@ -21,7 +21,7 @@
 
   <div class="button-submit-wrapper">
     <%= if assigns[:product] do %>
-      <%= link "Remove Product", class: "btn btn-secondary mr-3", to: Routes.product_path(@conn, :delete, @org.name, @product.name), method: :delete, data: [confirm: "Are you sure you want to delete this product? This can not be undone."] %>
+      <%= link "Remove Product", class: "btn btn-secondary", to: Routes.product_path(@conn, :delete, @org.name, @product.name), method: :delete, data: [confirm: "Are you sure you want to delete this product? This can not be undone."] %>
       <%= submit "Save Changes", class: "btn btn-primary", disabled: "true" %>
     <% else %>
       <%= submit "Create Product", class: "btn btn-primary" %>

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/deployment_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/deployment_controller_test.exs
@@ -57,7 +57,7 @@ defmodule NervesHubWWWWeb.DeploymentControllerTest do
       Fixtures.firmware_fixture(org_key, product)
       conn = get(conn, Routes.deployment_path(conn, :new, org.name, product.name))
 
-      assert html_response(conn, 200) =~ "Select Firmware for New Deployment"
+      assert html_response(conn, 200) =~ "Select Firmware"
 
       assert html_response(conn, 200) =~
                Routes.deployment_path(conn, :create, org.name, product.name)

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/firmware_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/firmware_controller_test.exs
@@ -92,7 +92,7 @@ defmodule NervesHubWWWWeb.FirmwareControllerTest do
         })
 
       assert html_response(conn, 200) =~
-               "Firmware corrupt, signature invalid or missing public key"
+               "Firmware corrupt, signature invalid, or missing public key"
     end
 
     test "error if org keys do not match firmware", %{
@@ -119,7 +119,7 @@ defmodule NervesHubWWWWeb.FirmwareControllerTest do
         })
 
       assert html_response(conn, 200) =~
-               "Firmware corrupt, signature invalid or missing public key"
+               "Firmware corrupt, signature invalid, or missing public key"
     end
 
     test "error if meta-product does not match product name", %{


### PR DESCRIPTION
### WHY
* Need to ensure that the styles are usable across all pages
* Some general styling cleanup

### HOW
* Added some better base styles to pages I haven't had a chance to fully update yet. Largely: deployments, firmware, and TOS pages
* Added a better solution for sticky bottom footer (previously wasn't working on the TOS pages)
* Added some conditional css for typography and buttons to make things easier