### PR TITLE
Add reboot functionality to devices index

### DIFF
--- a/apps/nerves_hub_www/assets/css/_custom.scss
+++ b/apps/nerves_hub_www/assets/css/_custom.scss
@@ -79,6 +79,11 @@
     color: white;
     background-color: transparent;
   }
+
+  &:focus {
+    background-color: transparent;
+    outline: none;
+  }
 }
 
 .dropdown-toggle.options {

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/index.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/index.ex
@@ -107,7 +107,8 @@ defmodule NervesHubWWWWeb.DeviceLive.Index do
       ) do
     user = Repo.preload(user, :org_users)
 
-    device = Enum.find(devices, fn device -> device.id == String.to_integer(device_id) end)
+    device_id = String.to_integer(device_id)
+    device = Enum.find(devices, fn device -> device.id == device_id end)
 
     case Enum.find(user.org_users, &(&1.org_id == device.org_id)) do
       %{role: :admin} -> do_reboot(socket, :allowed, device)

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/index.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/live/device_live/index.ex
@@ -4,7 +4,6 @@ defmodule NervesHubWWWWeb.DeviceLive.Index do
   alias NervesHubDevice.Presence
   alias NervesHubWebCore.{Accounts, Products, Devices}
   alias NervesHubWWWWeb.DeviceView
-  alias NervesHubWWWWeb.DeviceLive.Show
 
   alias Phoenix.Socket.Broadcast
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
@@ -90,9 +90,13 @@
               <img src="/images/icons/more.svg" alt="options" />
             </a>
             <div class="dropdown-menu dropdown-menu-right">
-              <%= link "edit", class: "dropdown-item", to: Routes.device_path(@socket, :edit, @org.name, @product.name, device.identifier) %>
+              <%= link "details", class: "dropdown-item", to: Routes.device_path(@socket, :show, @org.name, @product.name, device.identifier) %>
               <div class="dropdown-divider"></div>
-              <%= link "delete", class: "dropdown-item", to: Routes.device_path(@socket, :delete, @org.name, @product.name, device.identifier), method: :delete, data: [confirm: "Are you sure?"] %>
+              <button class="dropdown-item" type="button" phx-click="reboot" phx-value-device-id="<%= device.id %>" <%= if device.status == "offline", do: "disabled" %> data-confirm="Are you sure?">
+                <span>Reboot</span>
+              </button>
+              <div class="dropdown-divider"></div>
+              <%= link "edit", class: "dropdown-item", to: Routes.device_path(@socket, :edit, @org.name, @product.name, device.identifier) %>
             </div>
           </div>
         </td>

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/live/device_live_index_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/live/device_live_index_test.exs
@@ -1,0 +1,50 @@
+defmodule NervesHubWWWWeb.DeviceLiveShowTest do
+  use NervesHubWWWWeb.ConnCase.Browser, async: false
+
+  import Phoenix.ChannelTest
+
+  alias NervesHubWebCore.{AuditLogs, Repo}
+  alias NervesHubWWWWeb.Endpoint
+
+  setup %{fixture: %{device: device}} do
+    Endpoint.subscribe("device:#{device.id}")
+  end
+
+  describe "handle_event" do
+    test "reboot allowed", %{conn: conn, fixture: fixture} do
+      %{device: device} = fixture
+      {:ok, view, _html} = live(conn, device_index_path(fixture))
+
+      before_audit_count = AuditLogs.logs_for(device) |> length
+
+      assert render_change(view, :reboot, %{"device-id" => device.id}) =~ "reboot-requested"
+      assert_broadcast("reboot", %{})
+
+      after_audit_count = AuditLogs.logs_for(device) |> length
+
+      assert after_audit_count == before_audit_count + 1
+    end
+
+    test "reboot blocked", %{conn: conn, fixture: fixture} do
+      %{device: device, user: user} = fixture
+
+      Repo.preload(user, :org_users)
+      |> Map.get(:org_users)
+      |> Enum.map(&NervesHubWebCore.Accounts.change_org_user_role(&1, :read))
+
+      {:ok, view, _html} = live(conn, device_index_path(fixture))
+
+      before_audit_count = AuditLogs.logs_for(device) |> length
+
+      assert render_change(view, :reboot, %{"device-id" => device.id}) =~ "reboot-blocked"
+
+      after_audit_count = AuditLogs.logs_for(device) |> length
+
+      assert after_audit_count == before_audit_count + 1
+    end
+  end
+
+  def device_index_path(%{org: org, product: product}) do
+    Routes.device_path(Endpoint, :index, org.name, product.name)
+  end
+end


### PR DESCRIPTION
### Why
- Add reboot functionality to devices index

### How
- Added similar to but different from existing code to the device_live/index.ex file to handle the reboot process
- Updated the action dropdown menu on the index screen to include reboot and details 
