### PR TITLE
Add status to devices table

### DIFF
--- a/apps/nerves_hub_www/assets/css/_typography.scss
+++ b/apps/nerves_hub_www/assets/css/_typography.scss
@@ -148,4 +148,8 @@ body {
   .tt-c {
     text-transform: capitalize;
   }
+
+  .tt-c-first-letter:first-letter {
+    text-transform: capitalize;
+  }
 }

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
@@ -81,7 +81,7 @@
             <% device.status == "online" -> %>
               Up to date
             <% true -> %>
-              <%= device.status %>
+              <%= display_status(device.status) %>
           <% end %>
         </td>
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
@@ -74,14 +74,14 @@
           <% end %>
         </td>
 
-        <td style="text-transform: capitalize;">
-        <%= cond do %>
-          <% device.status == "offline" -> %>
-            <span class="color-white-50">Unknown</span>
-          <% device.status == "online" -> %>
-            Up to date
-          <% true -> %>
-            <%= device.status %>
+        <td class="tt-c-first-letter">
+          <%= cond do %>
+            <% device.status == "offline" -> %>
+              <span class="color-white-50">Unknown</span>
+            <% device.status == "online" -> %>
+              Up to date
+            <% true -> %>
+              <%= device.status %>
           <% end %>
         </td>
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
@@ -24,9 +24,10 @@
     <thead>
       <tr>
         <%= devices_table_header("Identifier", "identifier", @current_sort, @sort_direction) %>
-        <%= devices_table_header("Connection", "status", @current_sort, @sort_direction) %>
+        <th>Connection</th>
         <%= devices_table_header("Last Handshake", "last_communication", @current_sort, @sort_direction) %>
         <th>Firmware</th>
+        <%= devices_table_header("Firmware Status", "status", @current_sort, @sort_direction) %>
         <%= devices_table_header("Groups", "tags", @current_sort, @sort_direction) %>
         <th></th>
       </tr>
@@ -70,6 +71,17 @@
                 <%= device.firmware_metadata.version %>
               </span>
             <% end %>
+          <% end %>
+        </td>
+
+        <td style="text-transform: capitalize;">
+        <%= cond do %>
+          <% device.status == "offline" -> %>
+            <span class="color-white-50">Unknown</span>
+          <% device.status == "online" -> %>
+            Up to date
+          <% true -> %>
+            <%= device.status %>
           <% end %>
         </td>
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/device_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/device_view.ex
@@ -32,6 +32,14 @@ defmodule NervesHubWWWWeb.DeviceView do
     content_tag(:th, title, phx_click: "sort", phx_value_sort: value, class: "pointer")
   end
 
+  def display_status(status) when is_binary(status) do
+    status
+    |> String.split("-")
+    |> Enum.join(" ")
+  end
+
+  def display_status(_), do: nil
+
   def platform_options do
     [
       "bbb",

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/live/device_live_index_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/live/device_live_index_test.exs
@@ -17,7 +17,7 @@ defmodule NervesHubWWWWeb.DeviceLiveIndexTest do
 
       before_audit_count = AuditLogs.logs_for(device) |> length
 
-      assert render_change(view, :reboot, %{"device-id" => device.id}) =~ "reboot-requested"
+      assert render_change(view, :reboot, %{"device-id" => device.id}) =~ "reboot requested"
       assert_broadcast("reboot", %{})
 
       after_audit_count = AuditLogs.logs_for(device) |> length
@@ -36,7 +36,7 @@ defmodule NervesHubWWWWeb.DeviceLiveIndexTest do
 
       before_audit_count = AuditLogs.logs_for(device) |> length
 
-      assert render_change(view, :reboot, %{"device-id" => device.id}) =~ "reboot-blocked"
+      assert render_change(view, :reboot, %{"device-id" => device.id}) =~ "reboot blocked"
 
       after_audit_count = AuditLogs.logs_for(device) |> length
 

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/views/device_view_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/views/device_view_test.exs
@@ -1,0 +1,19 @@
+defmodule NervesHubWWWWeb.DeviceViewTest do
+  use NervesHubWWWWeb.ConnCase, async: true
+
+  alias NervesHubWWWWeb.DeviceView
+
+  describe "display_status/1" do
+    test "nothing happens to regular strings" do
+      assert DeviceView.display_status("test status") == "test status"
+    end
+
+    test "hyphenated strings are formatted" do
+      assert DeviceView.display_status("test-status") == "test status"
+    end
+
+    test "nil is returned for other types" do
+      assert DeviceView.display_status(nil) == nil
+    end
+  end
+end


### PR DESCRIPTION
Why:

* We want to show the device/firmware status
* We want to convey online/offline as separate from status

This change addresses the need by:

* Adding a new column for status
* Making the original connection column unsortable
* Showing some predetermined status for online/offline
* Showing whatever other status may be in the status field
* Capitalizing statuses