### PR TITLE
Fix date rendering bug

### DIFF
--- a/apps/nerves_hub_www/assets/css/_audit_log_feed.scss
+++ b/apps/nerves_hub_www/assets/css/_audit_log_feed.scss
@@ -3,7 +3,8 @@
   background: var(--backgroundLight);
   border-radius: 4px;
   margin-bottom: 1rem;
-  display: flex;
+  display: grid;
+  grid-template-columns: max-content 1fr;
   align-items: center;
 
   .audit-description {

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account_certificate/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account_certificate/index.html.eex
@@ -27,10 +27,10 @@
       <% end %>
     </td>
     <td>
-      <%= if !is_nil(cert.not_before) do DateTimeFormat.format_date(cert.not_before) end %>
+      <%= if !is_nil(cert.not_before) do cert.not_before end %>
     </td>
     <td>
-      <%= if !is_nil(cert.not_after) do DateTimeFormat.format_date(cert.not_after) end %>
+      <%= if !is_nil(cert.not_after) do cert.not_after end %>
     </td>
     <td>
       <%= link "Delete", class: "btn btn-danger", to: Routes.account_certificate_path(@conn, :delete, @user.username, cert), method: :delete, data: [confirm: "Are you sure?"]%>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account_certificate/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account_certificate/index.html.eex
@@ -27,10 +27,10 @@
       <% end %>
     </td>
     <td>
-      <%= DateTimeFormat.format_date(cert.not_before) %>
+      <%= if !is_nil(cert.not_before) do DateTimeFormat.format_date(cert.not_before) end %>
     </td>
     <td>
-      <%= DateTimeFormat.format_date(cert.not_after) %>
+      <%= if !is_nil(cert.not_after) do DateTimeFormat.format_date(cert.not_after) end %>
     </td>
     <td>
       <%= link "Delete", class: "btn btn-danger", to: Routes.account_certificate_path(@conn, :delete, @user.username, cert), method: :delete, data: [confirm: "Are you sure?"]%>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account_certificate/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account_certificate/index.html.eex
@@ -27,10 +27,10 @@
       <% end %>
     </td>
     <td>
-      <%= if !is_nil(cert.not_before) do cert.not_before end %>
+      <%= cert.not_before %>
     </td>
     <td>
-      <%= if !is_nil(cert.not_after) do cert.not_after end %>
+      <%= cert.not_after %>
     </td>
     <td>
       <%= link "Delete", class: "btn btn-danger", to: Routes.account_certificate_path(@conn, :delete, @user.username, cert), method: :delete, data: [confirm: "Are you sure?"]%>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/audit_log/_audit_log_feed.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/audit_log/_audit_log_feed.html.eex
@@ -7,9 +7,9 @@
         <div class="audit-action-icon icon-<%= audit_log.action %>"></div>
         <div>
           <p class="audit-description"><%= audit_log.description %></p>
-          <div class="help-text">
-            <%= DateTimeFormat.from_now(audit_log.inserted_at) %>
-          </div>
+            <div class="help-text">
+              <%= if !is_nil(audit_log.inserted_at) do DateTimeFormat.from_now(audit_log.inserted_at) end %>
+            </div>
         </div>
       </div>
     <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/audit_log/_audit_log_feed.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/audit_log/_audit_log_feed.html.eex
@@ -8,7 +8,7 @@
         <div>
           <p class="audit-description"><%= audit_log.description %></p>
             <div class="help-text">
-              <%= if !is_nil(audit_log.inserted_at) do DateTimeFormat.from_now(audit_log.inserted_at) end %>
+              <%= DateTimeFormat.from_now(audit_log.inserted_at) %>
             </div>
         </div>
       </div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/index.html.eex
@@ -37,7 +37,13 @@
         </td>
         <td><%= firmware.version %></td>
         <td><span class="badge"><%= format_signed(firmware, @org) %></span></td>
-        <td><%= DateTimeFormat.date_at_time(firmware.inserted_at) %></td>
+        <td>
+          <%= if is_nil(firmware.inserted_at) do %>
+            <span class="color-white-50">Never</span>
+          <% else %>
+            <%= DateTimeFormat.date_at_time(firmware.inserted_at) %>
+          <% end %>
+        </td>
         <td class="actions">
           <div class="dropdown options">
             <a class="dropdown-toggle options" href="#" id="<%= firmware.uuid %>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/index.html.eex
@@ -41,7 +41,7 @@
           <%= if is_nil(firmware.inserted_at) do %>
             <span class="color-white-50">Never</span>
           <% else %>
-            <%= DateTimeFormat.date_at_time(firmware.inserted_at) %>
+            <%= firmware.inserted_at %>
           <% end %>
         </td>
         <td class="actions">

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/show.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/show.html.eex
@@ -30,7 +30,9 @@
   </div>
   <div>
     <div class="help-text">Created On</div>
-    <p><%= DateTimeFormat.date_at_time(@firmware.inserted_at) %></p>
+    <p>
+      <%= if !is_nil(@firmware.inserted_at) do DateTimeFormat.date_at_time(@firmware.inserted_at) end %>
+    </p>
   </div>
   <div>
     <div class="help-text">VCS ID</div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/show.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/show.html.eex
@@ -31,7 +31,7 @@
   <div>
     <div class="help-text">Created On</div>
     <p>
-      <%= if !is_nil(@firmware.inserted_at) do @firmware.inserted_at end %>
+      <%= @firmware.inserted_at %>
     </p>
   </div>
   <div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/show.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/show.html.eex
@@ -31,7 +31,7 @@
   <div>
     <div class="help-text">Created On</div>
     <p>
-      <%= if !is_nil(@firmware.inserted_at) do DateTimeFormat.date_at_time(@firmware.inserted_at) end %>
+      <%= if !is_nil(@firmware.inserted_at) do @firmware.inserted_at end %>
     </p>
   </div>
   <div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/index.html.eex
@@ -31,10 +31,10 @@
           <% end %>
         </td>
         <td>
-          <%= if !is_nil(cert.not_before) do cert.not_before end %>
+          <%= cert.not_before %>
         </td>
         <td>
-          <%= if !is_nil(cert.not_after) do cert.not_after end %>
+          <%= cert.not_after %>
         </td>
       </tr>
     <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/index.html.eex
@@ -31,10 +31,10 @@
           <% end %>
         </td>
         <td>
-          <%= DateTimeFormat.format_date(cert.not_before) %>
+          <%= if !is_nil(cert.not_before) do DateTimeFormat.format_date(cert.not_before) end %>
         </td>
         <td>
-          <%= DateTimeFormat.format_date(cert.not_after) %>
+          <%= if !is_nil(cert.not_after) do DateTimeFormat.format_date(cert.not_after) end %>
         </td>
       </tr>
     <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/index.html.eex
@@ -31,10 +31,10 @@
           <% end %>
         </td>
         <td>
-          <%= if !is_nil(cert.not_before) do DateTimeFormat.format_date(cert.not_before) end %>
+          <%= if !is_nil(cert.not_before) do cert.not_before end %>
         </td>
         <td>
-          <%= if !is_nil(cert.not_after) do DateTimeFormat.format_date(cert.not_after) end %>
+          <%= if !is_nil(cert.not_after) do cert.not_after end %>
         </td>
       </tr>
     <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_user/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_user/index.html.eex
@@ -36,7 +36,7 @@
           <%= org_user.role %>
         </td>
         <td>
-          <%= if !is_nil(org_user.user.inserted_at) do DateTimeFormat.format_date(org_user.user.inserted_at) end %>
+          <%= if !is_nil(org_user.user.inserted_at) do org_user.user.inserted_at end %>
         </td>
       </tr>
     <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_user/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_user/index.html.eex
@@ -36,7 +36,7 @@
           <%= org_user.role %>
         </td>
         <td>
-          <%= if !is_nil(org_user.user.inserted_at) do org_user.user.inserted_at end %>
+          <%= org_user.user.inserted_at %>
         </td>
       </tr>
     <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_user/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_user/index.html.eex
@@ -36,7 +36,7 @@
           <%= org_user.role %>
         </td>
         <td>
-          <%= DateTimeFormat.format_date(org_user.user.inserted_at) %>
+          <%= if !is_nil(org_user.user.inserted_at) do DateTimeFormat.format_date(org_user.user.inserted_at) end %>
         </td>
       </tr>
     <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/firmware_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/firmware_view.ex
@@ -1,8 +1,6 @@
 defmodule NervesHubWWWWeb.FirmwareView do
   use NervesHubWWWWeb, :view
 
-  alias NervesHubWWWWeb.LayoutView.DateTimeFormat, as: DateTimeFormat
-
   def format_signed(%{org_key_id: org_key_id}, org) do
     key = Enum.find(org.org_keys, &(&1.id == org_key_id))
     "#{key.name}"

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
@@ -275,61 +275,9 @@ defmodule NervesHubWWWWeb.LayoutView do
   end
 
   defmodule DateTimeFormat do
-    @months %{
-      1 => "Jan",
-      2 => "Feb",
-      3 => "Mar",
-      4 => "Apr",
-      5 => "May",
-      6 => "Jun",
-      7 => "Jul",
-      8 => "Aug",
-      9 => "Sep",
-      10 => "Oct",
-      11 => "Nov",
-      12 => "Dec"
-    }
-
-    def format_date(timestamp) do
-      if Timex.is_valid?(timestamp) do
-        localTimestamp = Timex.local(timestamp)
-        '#{@months[localTimestamp.month]} #{localTimestamp.day}, #{localTimestamp.year}'
-      else
-        timestamp
-      end
-    end
-
-    def date_at_time(timestamp) do
-      if Timex.is_valid?(timestamp) do
-        localTimestamp = Timex.local(timestamp)
-        minute = localTimestamp.minute
-        {hour, label} = Timex.Time.to_12hour_clock(localTimestamp.hour)
-        compareDates = Date.compare(localTimestamp, DateTime.utc_now())
-
-        if compareDates == :eq do
-          'Today at #{hour}:#{render_minute(minute)}#{label}'
-        else
-          '#{@months[localTimestamp.month]} #{localTimestamp.day}, #{localTimestamp.year} at #{hour}:#{
-            render_minute(minute)
-          }#{label}'
-        end
-      else
-        timestamp
-      end
-    end
-
-    def render_minute(minute) do
-      if minute == 0 do
-        '00'
-      else
-        minute
-      end
-    end
-
     def from_now(timestamp) do
       if Timex.is_valid?(timestamp) do
-        localTimestamp = Timex.local(timestamp)
-        Timex.from_now(localTimestamp)
+        Timex.from_now(timestamp)
       else
         timestamp
       end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
@@ -291,22 +291,30 @@ defmodule NervesHubWWWWeb.LayoutView do
     }
 
     def format_date(timestamp) do
-      localTimestamp = Timex.local(timestamp)
-      '#{@months[localTimestamp.month]} #{localTimestamp.day}, #{localTimestamp.year}'
+      if Timex.is_valid?(timestamp) do
+        localTimestamp = Timex.local(timestamp)
+        '#{@months[localTimestamp.month]} #{localTimestamp.day}, #{localTimestamp.year}'
+      else
+        timestamp
+      end
     end
 
     def date_at_time(timestamp) do
-      localTimestamp = Timex.local(timestamp)
-      minute = localTimestamp.minute
-      {hour, label} = Timex.Time.to_12hour_clock(localTimestamp.hour)
-      compareDates = Date.compare(localTimestamp, DateTime.utc_now())
+      if Timex.is_valid?(timestamp) do
+        localTimestamp = Timex.local(timestamp)
+        minute = localTimestamp.minute
+        {hour, label} = Timex.Time.to_12hour_clock(localTimestamp.hour)
+        compareDates = Date.compare(localTimestamp, DateTime.utc_now())
 
-      if compareDates == :eq do
-        'Today at #{hour}:#{render_minute(minute)}#{label}'
+        if compareDates == :eq do
+          'Today at #{hour}:#{render_minute(minute)}#{label}'
+        else
+          '#{@months[localTimestamp.month]} #{localTimestamp.day}, #{localTimestamp.year} at #{hour}:#{
+            render_minute(minute)
+          }#{label}'
+        end
       else
-        '#{@months[localTimestamp.month]} #{localTimestamp.day}, #{localTimestamp.year} at #{hour}:#{
-          render_minute(minute)
-        }#{label}'
+        timestamp
       end
     end
 
@@ -319,8 +327,12 @@ defmodule NervesHubWWWWeb.LayoutView do
     end
 
     def from_now(timestamp) do
-      localTimestamp = Timex.local(timestamp)
-      Timex.from_now(localTimestamp)
+      if Timex.is_valid?(timestamp) do
+        localTimestamp = Timex.local(timestamp)
+        Timex.from_now(localTimestamp)
+      else
+        timestamp
+      end
     end
   end
 end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/org_user_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/org_user_view.ex
@@ -1,5 +1,3 @@
 defmodule NervesHubWWWWeb.OrgUserView do
   use NervesHubWWWWeb, :view
-
-  alias NervesHubWWWWeb.LayoutView.DateTimeFormat, as: DateTimeFormat
 end


### PR DESCRIPTION
### Why
* Timex.local is preventing pages from rendering on staging due to trying to use the server's local timezone

### How
* Add some conditionals around date rendering to make sure a date exists
* Remove Timex formatting being used for specific date and times since it won't show the user's correct timezone
* Can still use `from_now` safely
* Will have to format dates using javascript going forward