### PR TITLE
Format dates with javascript

### DIFF
--- a/apps/nerves_hub_www/assets/css/_custom.scss
+++ b/apps/nerves_hub_www/assets/css/_custom.scss
@@ -66,6 +66,7 @@
     margin-top: .5rem;
   }
 }
+
 .options .dropdown-item {
   color: var(--white-50);
   transition: color 200ms ease;
@@ -84,6 +85,10 @@
     background-color: transparent;
     outline: none;
   }
+}
+
+.dropdown-toggle:focus {
+  outline: none;
 }
 
 .dropdown-toggle.options {

--- a/apps/nerves_hub_www/assets/css/app.scss
+++ b/apps/nerves_hub_www/assets/css/app.scss
@@ -3,7 +3,7 @@ $fa-font-path: '~@fortawesome/fontawesome-free/webfonts';
 @import '~@fortawesome/fontawesome-free/scss/solid';
 @import '~@fortawesome/fontawesome-free/scss/regular';
 @import '~@fortawesome/fontawesome-free/scss/brands';
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,400;0,500;0,700;1,400;1,500&display=swap');
 
 @import "~xterm/css/xterm.css";
 @import "audit_log_feed";

--- a/apps/nerves_hub_www/assets/js/app.js
+++ b/apps/nerves_hub_www/assets/js/app.js
@@ -7,6 +7,7 @@ import { Socket } from 'phoenix'
 import LiveSocket from 'phoenix_live_view'
 import IEx from './console'
 
+let dates = require('./dates')
 const iex = new IEx()
 let csrfToken = document
   .querySelector("meta[name='csrf-token']")
@@ -30,6 +31,10 @@ $(function() {
       .addClass('selected')
       .html("Selected File: <div class='file-name'>" + fileName + '</div>')
   })
+})
+
+document.querySelectorAll('.date-time').forEach(d => {
+  d.innerHTML = dates.formatDateTime(d.innerHTML)
 })
 
 if (window.location.pathname.endsWith('console')) {

--- a/apps/nerves_hub_www/assets/js/dates.js
+++ b/apps/nerves_hub_www/assets/js/dates.js
@@ -1,3 +1,5 @@
+let moment = require('moment')
+
 let formatDateTime = datetime => {
   /*
     Safari wants strict iso8601 format "YYYY-MM-DDTHH:MM:SSZ",
@@ -9,11 +11,11 @@ let formatDateTime = datetime => {
     .split(' ')
     .join('T')
 
-  if (datetime == 'never' || datetime == '') {
+  if (datetime === 'never' || datetime === '') {
     return datetime
   } else {
     const date = new Date(datetime)
-    return date.toLocaleString('en-US', { timeZoneName: 'short' })
+    return moment(date).format("MMM Do, YYYY [at] h:mma")
   }
 }
 

--- a/apps/nerves_hub_www/assets/js/dates.js
+++ b/apps/nerves_hub_www/assets/js/dates.js
@@ -14,8 +14,10 @@ let formatDateTime = datetime => {
   if (datetime === 'never' || datetime === '') {
     return datetime
   } else {
-    const date = new Date(datetime)
-    return moment(date).format('MMM Do, YYYY [at] h:mma')
+    return moment
+      .utc(datetime)
+      .local()
+      .format('MMM Do, YYYY [at] h:mma')
   }
 }
 

--- a/apps/nerves_hub_www/assets/js/dates.js
+++ b/apps/nerves_hub_www/assets/js/dates.js
@@ -15,7 +15,7 @@ let formatDateTime = datetime => {
     return datetime
   } else {
     const date = new Date(datetime)
-    return moment(date).format("MMM Do, YYYY [at] h:mma")
+    return moment(date).format('MMM Do, YYYY [at] h:mma')
   }
 }
 

--- a/apps/nerves_hub_www/assets/package-lock.json
+++ b/apps/nerves_hub_www/assets/package-lock.json
@@ -6964,6 +6964,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "moment": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/apps/nerves_hub_www/assets/package.json
+++ b/apps/nerves_hub_www/assets/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "bootstrap": "^4.4.1",
     "jquery": "^3.5.1",
+    "moment": "^2.27.0",
     "phoenix": "file:../../../deps/phoenix",
     "phoenix_html": "file:../../../deps/phoenix_html",
     "phoenix_live_view": "file:../../../deps/phoenix_live_view",

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account_certificate/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account_certificate/index.html.eex
@@ -26,10 +26,10 @@
         <span class="text-muted">Never</span>
       <% end %>
     </td>
-    <td>
+    <td class="date-time">
       <%= cert.not_before %>
     </td>
-    <td>
+    <td class="date-time">
       <%= cert.not_after %>
     </td>
     <td>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/edit.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/edit.html.leex
@@ -17,7 +17,7 @@
     <label for="description_input" class="tooltip-label h3 mb-1">
       <span>Description</span>
       <span class="tooltip-info"></span>
-      <span class="tooltip-text">Description for this device (not required)</span>
+      <span class="tooltip-text">Description for this device</span>
     </label>
     <%= text_input f, :description, class: "form-control", id: "description_input" %>
     <div class="has-error"><%= error_tag f, :description %></div>
@@ -27,7 +27,7 @@
     <label for="tags" class="tooltip-label h3 mb-1">
       <span>Group(s)</span>
       <span class="tooltip-info"></span>
-      <span class="tooltip-text">TEMP description for groups</span>
+      <span class="tooltip-text">Use groups to manage firmware deployments for different sets of devices.</span>
     </label>
     <%= text_input f, :tags, class: "form-control", id: "tags", value: tags_to_string(@changeset) %>
     <small class="form-text text-muted mt-1">

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/new.html.eex
@@ -15,7 +15,7 @@
     <label for="description_input" class="tooltip-label h3 mb-1">
       <span>Description</span>
       <span class="tooltip-info"></span>
-      <span class="tooltip-text">Description for this device (not required)</span>
+      <span class="tooltip-text">Description for this device</span>
     </label>
     <%= text_input f, :description, class: "form-control", id: "description_input" %>
     <div class="has-error"><%= error_tag f, :description %></div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/index.html.eex
@@ -41,7 +41,7 @@
           <%= if is_nil(firmware.inserted_at) do %>
             <span class="color-white-50">Never</span>
           <% else %>
-            <%= firmware.inserted_at %>
+            <span class="date-time"><%= firmware.inserted_at %></span>
           <% end %>
         </td>
         <td class="actions">

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/show.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/firmware/show.html.eex
@@ -30,7 +30,7 @@
   </div>
   <div>
     <div class="help-text">Created On</div>
-    <p>
+    <p class="date-time">
       <%= @firmware.inserted_at %>
     </p>
   </div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_certificate/index.html.eex
@@ -30,10 +30,10 @@
             <span class="text-muted">Never</span>
           <% end %>
         </td>
-        <td>
+        <td class="date-time">
           <%= cert.not_before %>
         </td>
-        <td>
+        <td class="date-time">
           <%= cert.not_after %>
         </td>
       </tr>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_user/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_user/index.html.eex
@@ -35,7 +35,7 @@
         <td class="tt-c">
           <%= org_user.role %>
         </td>
-        <td>
+        <td class="date-time">
           <%= org_user.user.inserted_at %>
         </td>
       </tr>


### PR DESCRIPTION
### Why
- Dates rendered at specific times need to be formatted with javascript

### How
- Added moment.js to assist with formatting. Using a helper class `date-time` to find dates that need to be formatted

### Notes
- @Mrjaco12 This might be a local issue but it seems like the timezone portion of the inserted_at value is not being included. The expected string would be `YYYY-MM-DD HH:MM:SSZ` but we're receiving `YYYY-MM-DD HH:MM:SS`. This is resulting in the time being incorrect and weirdly differing from browser to browser (safari is showing my correct time). My plan was to see this on staging and see how it functions there.
**EDIT: disregard above**