### PR TITLE
Fix js test for new date formatting

### DIFF
--- a/apps/nerves_hub_www/assets/js/dates.js
+++ b/apps/nerves_hub_www/assets/js/dates.js
@@ -1,4 +1,6 @@
-let formatDateTime = datetime => {
+const moment = require('moment')
+
+const formatDateTime = datetime => {
   /*
     Safari wants strict iso8601 format "YYYY-MM-DDTHH:MM:SSZ",
     but elixir to_string default supplies as "YYYY-MM-DD HH:MM:SSZ".
@@ -9,11 +11,13 @@ let formatDateTime = datetime => {
     .split(' ')
     .join('T')
 
-  if (datetime == 'never' || datetime == '') {
+  if (datetime === 'never' || datetime === '') {
     return datetime
   } else {
-    const date = new Date(datetime)
-    return date.toLocaleString('en-US', { timeZoneName: 'short' })
+    return moment
+      .utc(datetime)
+      .local()
+      .format('MMM Do, YYYY [at] h:mma')
   }
 }
 

--- a/apps/nerves_hub_www/assets/js/dates.test.js
+++ b/apps/nerves_hub_www/assets/js/dates.test.js
@@ -1,13 +1,15 @@
 const dates = require('./dates')
+const moment = require('moment')
 
 describe('formatDateTime', () => {
   test('formats ISO 8601 dates', () => {
     let date = new Date()
+    let testDate = moment
+      .utc(date)
+      .local()
+      .format('MMM Do, YYYY [at] h:mma')
 
-    date.setMilliseconds(0)
-    expect(new Date(dates.formatDateTime(date.toISOString())).getTime()).toBe(
-      date.getTime()
-    )
+    expect(dates.formatDateTime(date.toISOString())).toBe(testDate)
   })
 
   test('preserves "never" value', () => {


### PR DESCRIPTION
### Why
- JS testing needs to be updated to reflect the new date formatting