### PR TITLE
Update deployments index and add device health to device index table

### DIFF
--- a/apps/nerves_hub_www/assets/css/_custom.scss
+++ b/apps/nerves_hub_www/assets/css/_custom.scss
@@ -174,6 +174,14 @@
   padding: 2.5rem;
   border-radius: 4px;
   margin-bottom: 2rem;
+
+  .item {
+    margin-bottom: 2.5rem;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
 }
 
 .back-link {
@@ -186,7 +194,8 @@
   line-height: 44px;
 }
 
-.device-meta-grid {
+.device-meta-grid,
+.deployment-meta-grid {
   display: grid;
   grid-template-columns: max-content max-content max-content 1fr;
   grid-column-gap: 7.5rem;

--- a/apps/nerves_hub_www/assets/css/_form.scss
+++ b/apps/nerves_hub_www/assets/css/_form.scss
@@ -141,6 +141,7 @@ html {
   select {
     -webkit-appearance: none;
     -moz-appearance: none;
+    cursor: pointer;
 
     & + .select-icon {
       pointer-events: none;

--- a/apps/nerves_hub_www/assets/css/_table.scss
+++ b/apps/nerves_hub_www/assets/css/_table.scss
@@ -55,4 +55,20 @@ html {
     width: 1.5rem;
     height: 1.5rem;
   }
+
+  .deployment-state {
+    background-size: 1.5rem;
+    background-repeat: no-repeat;
+    background-position: left center;
+    padding-left: 2rem;
+    line-height: 1.5rem;
+
+    &.state-on {
+      background-image: url("/images/icons/check.svg");
+    }
+
+    &.state-off {
+      background-image: url("/images/icons/cross.svg");
+    }
+  }
 }

--- a/apps/nerves_hub_www/assets/css/app.scss
+++ b/apps/nerves_hub_www/assets/css/app.scss
@@ -57,6 +57,7 @@ html {
 .badge {
   height: 36px;
   background-color: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.05);
   padding: .75rem;
   border-radius: 4px;
   display: inline-flex;
@@ -65,14 +66,12 @@ html {
   font-size: 16px;
   overflow: hidden;
   position: relative;
+  margin-right: .5rem;
+  margin-top: .5rem;
+  margin-bottom: .5rem;
 
   &.healthy-false {
     background-color: var(--primary-25);
-    background-image: url("/images/icons/error.svg");
-    background-size: 1.5rem;
-    background-repeat: no-repeat;
-    background-position: right .5rem center;
-    padding-right: 2.5rem;
 
     &:hover {
       color: white;
@@ -91,9 +90,17 @@ html {
     background: white;
   }
 
-  & + .badge {
-    margin-left: .5rem;
+  &:last-child {
+    margin-right: 0;
   }
+}
+
+.quarantined {
+  background-image: url("/images/icons/error.svg");
+  background-size: 1.5rem;
+  background-repeat: no-repeat;
+  background-position: right .5rem center;
+  padding-right: 2.5rem;
 }
 
 .alert {

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/index.html.eex
@@ -24,24 +24,40 @@
     <thead>
       <tr>
         <th>Name</th>
-        <th>Firmware</th>
-        <th>Conditions</th>
-        <th>Status</th>
-        <th></th>
+        <th>State</th>
+        <th>Firmware version</th>
+        <th>Distributed to</th>
+        <th>Version requirement</th>
       </tr>
     </thead>
     <%= for deployment <- @deployments do %>
       <tr class="item">
         <td><a href="<%= Routes.deployment_path(@conn, :show, @org.name, @product.name, deployment.name) %>"><%= deployment.name %></a></td>
-        <td><span><%= firmware_display_name(deployment.firmware) %></span></td>
-        <td><span class="pre-scrollable"><%= deployment.conditions |> Jason.encode!() %></span></td>
         <td>
-          <span class="label label-<%= if deployment.is_active, do: "success", else: "default" %>">
-            <%= if deployment.is_active, do: "Active", else: "Inactive" %>
-          </span>
+          <div class="deployment-state state-<%= if deployment.is_active, do: "on", else: "off" %>">
+            <%= if deployment.is_active, do: "On", else: "Off" %>
+          </div>
         </td>
+        <td><span class="badge"><%= firmware_display_name(deployment.firmware) %></span></td>
+        <td>
+          <%= for tag <- tags(deployment) do %>
+            <span class="badge">
+              <%= tag %>
+            </span>
+          <% end %>
+        </td>
+        <td><%= version(deployment) %></td>
         <td class="actions">
-          <%= link "delete", class: "fa fa-trash-alt color-white", to: Routes.deployment_path(@conn, :delete, @org.name, @product.name, deployment.name), method: :delete, data: [confirm: "Are you sure you want to delete this deployment? This can not be undone."] %>
+          <div class="dropdown options">
+            <a class="dropdown-toggle options" href="#" id="<%= deployment.id %>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <img src="/images/icons/more.svg" alt="options" />
+            </a>
+            <div class="dropdown-menu dropdown-menu-right">
+              <%= link "details", class: "dropdown-item", to: Routes.deployment_path(@conn, :show, @org.name, @product.name, deployment.name) %>
+              <div class="dropdown-divider"></div>
+              <%= link "edit", class: "dropdown-item", to: Routes.deployment_path(@conn, :edit, @org.name, @product.name, deployment.name) %>
+            </div>
+          </div>
         </td>
       </tr>
     <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/new.html.eex
@@ -23,7 +23,7 @@
   </div>
 
   <div class="form-group">
-    <label for="verion_input">Tag(s)*</label>
+    <label for="verion_input">Group(s)</label>
     <%= text_input f, :tags,
           class: "form-control",
           id: "version_input",

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/select-firmware.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/select-firmware.html.eex
@@ -3,6 +3,7 @@
   <div class="form-group">
     <label for="firmware_id">Firmware</label>
     <%= select f, :firmware_id, firmware_dropdown_options(@firmwares), required: true, id: "firmware_id", class: "form-control" %>
+    <div class="select-icon"></div>
     <div class="has-error"><%= error_tag f, :firmware_id %></div>
   </div>
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/show.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/deployment/show.html.leex
@@ -1,40 +1,55 @@
-<h1>Deployment: <%= @deployment.name %></h1>
+<div class="flex-row justify-content-between align-items-center">
+  <%= link "All Deployments", to: Routes.deployment_path(@socket, :index, @org.name, @product.name), class: "back-link"%>
+  <div class="btn-group" role="group" aria-label="Deployment Actions">
+    <a class="btn btn-outline-light" href="<%= Routes.deployment_path(@socket, :edit, @org.name, @product.name, @deployment.name) %>">
+      Edit Deployment
+    </a>
+  </div>
+</div>
+
+<h1><%= @deployment.name %></h1>
+
+<div class="deployment-meta-grid">
+  <div>
+    <div class="help-text">State</div>
+    <p class="deployment-state state-<%= if @deployment.is_active, do: "on", else: "off" %>">
+      <%= if @deployment.is_active, do: "On", else: "Off" %>
+    </p>
+  </div>
+</div>
 
 <div class="divider"></div>
 
 <div class="row">
   <div class="col-lg-7">
+    <h3 class="mb-2">Deployment Details</h3>
+    <div class="display-box">
+      <div class="item">
+        <div class="help-text mb-1">Distributed to</div>
+        <%= if Enum.count(tags(@deployment)) > 0 do %>
+          <%= for tag <- tags(@deployment) do %>
+            <span class="badge">
+              <%= tag %>
+            </span>
+          <% end %>
+        <% else %>
+          <p>No Groups</p>
+        <% end %>
+      </div>
+      <div class="item">
+        <div class="help-text mb-1">Firmware version</div>
+        <span class="badge"><%= firmware_summary(@deployment) %></span>
+      </div>
+      <div class="item">
+        <div class="help-text mb-1">Version requirement</div>
+        <p><%= version(@deployment) %></p>
+      </div>
+    </div>
     <table class="table" style="width: auto">
       <tbody>
         <tr>
           <th>Product</th>
           <td><%= @product.name %></td>
-        </tr>
-        <tr>
-          <th>Active</th>
-          <td><%= active(@deployment) %>
-        </tr>
-        <tr>
-          <th>Healthy?</th>
-          <td><%= health_status_icon(@deployment) %>
-        </tr>
-        <tr>
-          <th>Version Requirement</th>
-          <td><%= version(@deployment) %></td>
-        </tr>
-        <tr>
-          <th>Tags</th>
-          <td>
-            <%= for tag <- tags(@deployment) do %>
-              <span class="badge">
-                <%= tag %>
-              </span>
-            <% end %>
-          </td>
-        </tr>
-        <tr>
-          <th>Firmware Info</th>
-          <td><%= firmware_summary(@deployment) %></td>
         </tr>
         <tr>
           <th>Failure Rate <%= help_icon(help_message_for(:failure_rate)) %></th>
@@ -56,15 +71,12 @@
     </table>
 
     <div class="button-submit-wrapper">
-      <a class="btn btn-primary" href="<%= Routes.deployment_path(@socket, :edit, @org.name, @product.name, @deployment.name) %>">
-        Edit Deployment
-      </a>
-      <a class="btn btn-primary" phx-click="toggle_active" phx-value-isactive=<%= !@deployment.is_active %>>Make <%= opposite_status(@deployment) %></a>
+      <a class="btn btn-outline-light" phx-click="toggle_active" phx-value-isactive=<%= !@deployment.is_active %>>Make <%= opposite_status(@deployment) %></a>
       <%= form_for %Plug.Conn{}, "#", [phx_submit: "toggle_health_state"], fn _f -> %>
-        <%= submit "Mark #{if @deployment.healthy, do: "Unhealthy", else: "Healthy"}", class: "btn btn-primary" %>
+      <%= submit "Mark #{if @deployment.healthy, do: "Unhealthy", else: "Healthy"}", class: "btn btn-outline-light" %>
       <% end %>
       <%= form_for %Plug.Conn{}, "#", [phx_submit: "delete"], fn _f -> %>
-        <%= submit "Delete Deployment", class: "btn btn-danger", onclick: "return confirm('Are you sure you want to delete this deployment? This can not be undone.')" %>
+      <%= submit "Delete Deployment", class: "btn btn-outline-light", onclick: "return confirm('Are you sure you want to delete this deployment? This can not be undone.')" %>
       <% end %>
     </div>
   </div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
@@ -43,7 +43,7 @@
 
         <td>
           <%= if device.healthy do %>
-            <span>Healthy</span>
+            <span>Good</span>
           <% else %>
             <span class="quarantined">Quarantined</span>
           <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
@@ -24,6 +24,7 @@
     <thead>
       <tr>
         <%= devices_table_header("Identifier", "identifier", @current_sort, @sort_direction) %>
+        <%= devices_table_header("Health", "healthy", @current_sort, @sort_direction) %>
         <th>Connection</th>
         <%= devices_table_header("Last Handshake", "last_communication", @current_sort, @sort_direction) %>
         <th>Firmware</th>
@@ -38,6 +39,14 @@
           <a href="<%= Routes.device_path(@socket, :show, @org.name, @product.name, device.identifier) %>" class="badge healthy-<%= device.healthy %>">
             <%= device.identifier %>
           </a>
+        </td>
+
+        <td>
+          <%= if device.healthy do %>
+            <span>Healthy</span>
+          <% else %>
+            <span class="quarantined">Quarantined</span>
+          <% end %>
         </td>
 
         <td>
@@ -87,11 +96,8 @@
 
         <td>
           <%= if !is_nil(device.tags) do %>
-            <%= for tag <- take_device_tags(device, 2) do %>
+            <%= for tag <- device.tags do %>
               <span class="badge"><%= tag %></span>
-            <% end %>
-            <%= if count_device_tags(device) > 2 do %>
-              <span class="badge">+<%= count_device_tags(device) - 2%></span>
             <% end %>
           <% end %>
         </td>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
@@ -45,7 +45,7 @@
   <div>
     <div class="help-text">Health</div>
     <p>
-      <%= if health_status_icon(@device) do %>
+      <%= if @device.healthy do %>
         Good
       <% else %>
         <span>Quarantined</span>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/deployment_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/deployment_view.ex
@@ -5,28 +5,23 @@ defmodule NervesHubWWWWeb.DeploymentView do
   alias NervesHubWebCore.Firmwares.Firmware
   alias NervesHubWebCore.Deployments.Deployment
 
-  import NervesHubWWWWeb.LayoutView, only: [health_status_icon: 1, help_icon: 1]
+  import NervesHubWWWWeb.LayoutView, only: [help_icon: 1]
 
   def firmware_dropdown_options(firmwares) do
     firmwares
     |> Enum.map(&[value: &1.id, key: firmware_display_name(&1)])
   end
 
-  def firmware_summary(%Firmware{version: nil} = f) do
+  def firmware_summary(%Firmware{version: nil}) do
     [
-      f.platform,
-      f.architecture
+      "Unknown"
     ]
-    |> Enum.join(" - ")
   end
 
   def firmware_summary(%Firmware{} = f) do
     [
-      "v:#{firmware_display_name(f)}",
-      f.platform,
-      f.architecture
+      "#{firmware_display_name(f)}"
     ]
-    |> Enum.join(" - ")
   end
 
   def firmware_summary(%Deployment{firmware: %Firmware{} = f}) do

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/device_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/device_view.ex
@@ -4,8 +4,6 @@ defmodule NervesHubWWWWeb.DeviceView do
   alias NervesHubDevice.Presence
   alias NervesHubWWWWeb.LayoutView.DateTimeFormat, as: DateTimeFormat
 
-  import NervesHubWWWWeb.LayoutView, only: [health_status_icon: 1]
-
   def architecture_options do
     [
       "aarch64",
@@ -65,12 +63,4 @@ defmodule NervesHubWWWWeb.DeviceView do
   def tags_to_string(tags), do: tags
 
   defdelegate device_status(device), to: Presence
-
-  def take_device_tags(device, amount) do
-    Enum.take(device.tags, amount)
-  end
-
-  def count_device_tags(device) do
-    Enum.count(device.tags)
-  end
 end

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
@@ -65,18 +65,6 @@ defmodule NervesHubWWWWeb.LayoutView do
     Accounts.has_org_role?(org, user, role)
   end
 
-  def health_status_icon(%{healthy: healthy?}) do
-    {icon, color} = if healthy?, do: {"check-circle", "green"}, else: {"times-circle", "red"}
-    content_tag(:i, "", class: "fas fa-#{icon}", style: "color:#{color}")
-  end
-
-  def health_status_icon(_) do
-    content_tag(:i, "",
-      class: "fas fa-question-circle",
-      title: "Don't know how to tell health status"
-    )
-  end
-
   def help_icon(message, placement \\ :top) do
     content_tag(:i, "",
       class: "help-icon far fa-question-circle",

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/deployment_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/deployment_controller_test.exs
@@ -117,7 +117,7 @@ defmodule NervesHubWWWWeb.DeploymentControllerTest do
       # check that the proper creation side effects took place
       conn = get(conn, Routes.deployment_path(conn, :index, org.name, product.name))
       assert html_response(conn, 200) =~ deployment_params.name
-      assert html_response(conn, 200) =~ "Inactive"
+      assert html_response(conn, 200) =~ "Off"
       assert html_response(conn, 200) =~ firmware.version
     end
 


### PR DESCRIPTION
### Why
- Deployments index needs to be updated to match designs
- Add device health to device index
- Remove group badge display limit on device index
- Start of styling for deployment show page

### How
- Removed some functions that are no longer being used.
- Style updates
- Changed `firmware_summary` to reflect what we now need to be displayed

