### PR TITLE
Revert vocabulary changes

### DIFF
--- a/apps/nerves_hub_web_core/lib/nerves_hub_web_core/audit_logs/audit_log.ex
+++ b/apps/nerves_hub_web_core/lib/nerves_hub_web_core/audit_logs/audit_log.ex
@@ -206,10 +206,10 @@ defmodule NervesHubWebCore.AuditLogs.AuditLog do
       Map.keys(changes)
       |> case do
         [key] ->
-          "#{tags_to_groups(key)} field"
+          "#{key} field"
 
         [key1, key2] ->
-          "#{tags_to_groups(key1)} and #{tags_to_groups(key2)} fields"
+          "#{key1} and #{key2} fields"
 
         [last_key | rem] ->
           Enum.join(rem, ", ") <> ", and #{last_key} fields"
@@ -279,13 +279,5 @@ defmodule NervesHubWebCore.AuditLogs.AuditLog do
     #   user ron.swanson
     #   deployment Awesome Deployment
     "#{simple_type} #{identifier}"
-  end
-
-  defp tags_to_groups(key) do
-    if to_string(key) == "tags" do
-      "groups"
-    else
-      to_string(key)
-    end
   end
 end

--- a/apps/nerves_hub_web_core/test/nerves_hub_web_core/audit_logs/audit_log_test.exs
+++ b/apps/nerves_hub_web_core/test/nerves_hub_web_core/audit_logs/audit_log_test.exs
@@ -79,10 +79,10 @@ defmodule NervesHubWebCore.AuditLogs.AuditLogTest do
       two_changes = AuditLog.build(user, device, :update, %{description: "howdy", tags: ["wat"]})
 
       assert one_change.description ==
-               "user #{user.username} changed the groups field"
+               "user #{user.username} changed the tags field"
 
       assert two_changes.description ==
-               "user #{user.username} changed the description and groups fields"
+               "user #{user.username} changed the description and tags fields"
     end
 
     test "description for health changes", context do

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_controller.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/controllers/org_controller.ex
@@ -24,7 +24,7 @@ defmodule NervesHubWWWWeb.OrgController do
 
     with {:ok, org} <- Accounts.create_org(user, params) do
       conn
-      |> put_flash(:info, "Workspace created successfully.")
+      |> put_flash(:info, "Organization created successfully.")
       |> redirect(to: Routes.product_path(conn, :index, org.name))
     else
       {:error, %Ecto.Changeset{} = changeset} ->
@@ -49,7 +49,7 @@ defmodule NervesHubWWWWeb.OrgController do
     |> case do
       {:ok, org} ->
         conn
-        |> put_flash(:info, "Workspace Updated")
+        |> put_flash(:info, "Organization Updated")
         |> redirect(to: Routes.org_path(conn, :edit, org.name))
 
       {:error, changeset} ->

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/router.ex
@@ -97,7 +97,7 @@ defmodule NervesHubWWWWeb.Router do
         get("/:id/download", AccountCertificateController, :download)
       end
 
-      get("/workspaces", OrgController, :index)
+      get("/organizations", OrgController, :index)
     end
 
     get("/org/new", OrgController, :new)

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/invite.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/account/invite.html.eex
@@ -2,7 +2,7 @@
   <h2 class="form-title">
     Create New Account
   </h2>
-  <h5 class="mt-2"><%= gettext "You will be added to the %{organization_name} workspace", organization_name: @org.name %></h5>
+  <h5 class="mt-2"><%= gettext "You will be added to the %{organization_name} organization", organization_name: @org.name %></h5>
 
   <%= form_for @changeset, Routes.account_path(@conn, :accept_invite, @token), [as: :user, method: "post", class: "form-page"], fn f -> %>
     <div class="form-group">

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/edit.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/edit.html.leex
@@ -25,13 +25,13 @@
 
   <div class="form-group">
     <label for="tags" class="tooltip-label h3 mb-1">
-      <span>Group(s)</span>
+      <span>Tag(s)</span>
       <span class="tooltip-info"></span>
-      <span class="tooltip-text">Use groups to manage firmware deployments for different sets of devices.</span>
+      <span class="tooltip-text">Use tags to manage firmware deployments for different sets of devices.</span>
     </label>
     <%= text_input f, :tags, class: "form-control", id: "tags", value: tags_to_string(@changeset) %>
     <small class="form-text text-muted mt-1">
-      Every device is added to the 'all' group by default. You can have multiple groups separated by commas.
+      Every device is added to the 'all' tag by default. You can have multiple tags separated by commas.
     </small>
     <div class="has-error"><%= error_tag f, :tags %></div>
   </div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/index.html.leex
@@ -28,7 +28,7 @@
         <%= devices_table_header("Last Handshake", "last_communication", @current_sort, @sort_direction) %>
         <th>Firmware</th>
         <%= devices_table_header("Firmware Status", "status", @current_sort, @sort_direction) %>
-        <%= devices_table_header("Groups", "tags", @current_sort, @sort_direction) %>
+        <%= devices_table_header("Tags", "tags", @current_sort, @sort_direction) %>
         <th></th>
       </tr>
     </thead>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
@@ -71,13 +71,13 @@
   <div class="col-lg-7">
     <h3 class="mb-2">Deployments</h3>
     <div class="display-box">
-      <div class="help-text mb-1">Groups</div>
+      <div class="help-text mb-1">Tags</div>
       <%= if !is_nil(@device.tags) do %>
         <%= for tag <- @device.tags do %>
           <span class="badge"><%= tag %></span>
         <% end %>
       <% else %>
-        <p>No Groups</p>
+        <p>No Tags</p>
       <% end %>
     </div>
 

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.eex
@@ -12,7 +12,7 @@
           </a>
 
           <div class="dropdown-menu workspace-dropdown" aria-labelledby="navbarDropdownMenuLink">
-            <div class="help-text mt-3 pl-3 pr-3">Select organization</div>
+            <div class="help-text mt-3 pl-3 pr-3">Select an organization</div>
             <%= for org <- take_user_orgs(@conn, 5) do %>
               <div class="dropdown-submenu">
                 <%= active_link(@conn, to: Routes.product_path(@conn, :index, org.name), class_active: "active dropdown-item org", class_inactive: "dropdown-item org dropdown-toggle", aria_haspopup: "true") do %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/layout/_navigation.html.eex
@@ -12,7 +12,7 @@
           </a>
 
           <div class="dropdown-menu workspace-dropdown" aria-labelledby="navbarDropdownMenuLink">
-            <div class="help-text mt-3 pl-3 pr-3">Select a workspace</div>
+            <div class="help-text mt-3 pl-3 pr-3">Select organization</div>
             <%= for org <- take_user_orgs(@conn, 5) do %>
               <div class="dropdown-submenu">
                 <%= active_link(@conn, to: Routes.product_path(@conn, :index, org.name), class_active: "active dropdown-item org", class_inactive: "dropdown-item org dropdown-toggle", aria_haspopup: "true") do %>
@@ -50,11 +50,11 @@
             <% end %>
 
             <%= if count_user_orgs(@conn) > 5 do %>
-            <a class="all-nav-link" href="<%= Routes.org_path(@conn, :index, @conn.assigns.user.username) %>">View All Workspaces (<%= count_user_orgs(@conn) %>)</a>
+            <a class="all-nav-link" href="<%= Routes.org_path(@conn, :index, @conn.assigns.user.username) %>">View All Organizations (<%= count_user_orgs(@conn) %>)</a>
             <% end %>
 
             <a class="btn btn-outline-light mt-2 mb-3 ml-3 mr-3" href="<%= Routes.org_path(@conn, :new) %>">
-              Create Workspace
+              Create Organization
               <div class="button-icon add"></div>
             </a>
           </div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/edit.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/edit.html.eex
@@ -1,6 +1,4 @@
-<h1>
-  Workspace Settings
-</h1>
+<h1>Organization Settings</h1>
 
 <div class="x4-grid">
   <div>
@@ -27,7 +25,7 @@
   <%= form_for @org_changeset, Routes.org_path(@conn, :update, @org.name), fn f -> %>
     <div class="form-group">
       <label for="name_input" class="tooltip-label">
-        <span>Workspace Name</span>
+        <span>Organization Name</span>
         <span class="tooltip-info"></span>
         <span class="tooltip-text">Must be one word</span>
       </label>
@@ -40,9 +38,9 @@
   <%= form_for @org_changeset, Routes.org_path(@conn, :update, @org.name), fn f -> %>
   <div class="form-group">
     <label for="name_input" class="tooltip-label">
-      <span>Workspace Name</span>
+      <span>Organization Name</span>
       <span class="tooltip-info"></span>
-      <span class="tooltip-text">Your personal workspace matches your username</span>
+      <span class="tooltip-text">Your personal organization matches your username</span>
     </label>
     <%= text_input f, :name, class: "form-control", id: "name_input", disabled: "true" %>
     <div class="has-error"><%= error_tag f, :name %></div>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/form.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/form.html.eex
@@ -7,7 +7,7 @@
 
   <div class="form-group">
     <label for="name_input" class="tooltip-label">
-      <span>Workspace Name</span>
+      <span>Organization Name</span>
       <span class="tooltip-info"></span>
       <span class="tooltip-text">Must be one word</span>
     </label>
@@ -18,7 +18,7 @@
   </div>
 
   <div class="button-submit-wrapper">
-    <%= submit "Create Workspace", class: "btn btn-primary" %>
+    <%= submit "Create Organization", class: "btn btn-primary" %>
   </div>
 
 <% end %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/index.html.eex
@@ -1,4 +1,4 @@
-<h1>My Workspaces</h1>
+<h1>My Organizations</h1>
 <div class="x3-grid">
   <%= for org <- @orgs do %>
     <%= link to: Routes.product_path(@conn, :index, org.name), class: "grid-item" do %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/new.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org/new.html.eex
@@ -1,3 +1,3 @@
-<h1 class="pt-4">Create New Workspace</h1>
+<h1 class="pt-4">Create New Organization</h1>
 
 <%= render "form.html", Map.put(assigns, :action, Routes.org_path(@conn, :create)) %>

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_user/index.html.eex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/org_user/index.html.eex
@@ -11,7 +11,7 @@
 </div>
 
 <%= if @org.type == :user do %>
-  <h5 class="mb-6">This is your own personal workspace, additional users cannot be invited. <a class="inline" href="<%= Routes.org_path(@conn, :new) %>">Create a new workspace</a> to collaborate with others.</h5>
+  <h5 class="mb-6">This is your own personal organization, additional users cannot be invited. <a class="inline" href="<%= Routes.org_path(@conn, :new) %>">Create a new organization</a> to collaborate with others.</h5>
 <% end %>
 
 <table class="table table-sm table-hover">

--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/views/layout_view.ex
@@ -209,7 +209,7 @@ defmodule NervesHubWWWWeb.LayoutView do
              href: Routes.org_certificate_path(conn, :index, conn.assigns.org.name)
            },
            %{
-             title: "Workspace Settings",
+             title: "Organization Settings",
              active: "",
              href: Routes.org_path(conn, :edit, conn.assigns.org.name)
            }
@@ -256,7 +256,7 @@ defmodule NervesHubWWWWeb.LayoutView do
         href: Routes.account_path(conn, :edit, conn.assigns.user.username)
       },
       %{
-        title: "My Workspaces",
+        title: "My Organizations",
         active: "",
         href: Routes.org_path(conn, :index, conn.assigns.user.username)
       }

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/account_controller_test.exs
@@ -22,7 +22,7 @@ defmodule NervesHubWWWWeb.AccountControllerTest do
       conn = get(conn, Routes.account_path(conn, :invite, invite.token))
 
       assert html_response(conn, 200) =~
-               "You will be added to the #{conn.assigns.org.name} workspace"
+               "You will be added to the #{conn.assigns.org.name} organization"
     end
   end
 

--- a/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_controller_test.exs
+++ b/apps/nerves_hub_www/test/nerves_hub_www_web/controllers/org_controller_test.exs
@@ -6,7 +6,7 @@ defmodule NervesHubWWWWeb.OrgControllerTest do
   describe "new org" do
     test "renders form", %{conn: conn} do
       conn = get(conn, Routes.org_path(conn, :new))
-      assert html_response(conn, 200) =~ "Create New Workspace"
+      assert html_response(conn, 200) =~ "Create New Organization"
     end
   end
 
@@ -18,7 +18,7 @@ defmodule NervesHubWWWWeb.OrgControllerTest do
 
     test "renders errors when data is invalid", %{conn: conn} do
       conn = post(conn, Routes.org_path(conn, :create), org: %{})
-      assert html_response(conn, 200) =~ "Create New Workspace"
+      assert html_response(conn, 200) =~ "Create New Organization"
     end
   end
 
@@ -70,7 +70,7 @@ defmodule NervesHubWWWWeb.OrgControllerTest do
           org: %{name: ""}
         )
 
-      assert html_response(conn, 200) =~ "Workspace Settings"
+      assert html_response(conn, 200) =~ "Organization Settings"
       assert html_response(conn, 200) =~ "be blank"
     end
   end


### PR DESCRIPTION
### How and Why
- Revert vocabulary changes that were made due to feedback from the community.
- Change results in (the original): organizations and tags rather than workspaces and groups