### PR TITLE
Display firmware status on device show page

### DIFF
--- a/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
+++ b/apps/nerves_hub_www/lib/nerves_hub_www_web/templates/device/show.html.leex
@@ -101,7 +101,19 @@
           </div>
         <% end %>
       </div>
-
+      <div class="mt-4">
+        <div class="help-text mb-1">Status</div>
+        <div class="tt-c-first-letter">
+          <%= cond do %>
+            <% @device.status == "offline" -> %>
+              <span class="color-white-50">Unknown</span>
+            <% @device.status == "online" -> %>
+              Up to date
+            <% true -> %>
+              <%= display_status(@device.status) %>
+          <% end %>
+        </div>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
### Why
- Firmware status should be displayed on the device page

### How
- Rendering the same way being used on the index page